### PR TITLE
Install and configure hyprland dotfiles

### DIFF
--- a/hypr/hypridle.conf
+++ b/hypr/hypridle.conf
@@ -1,14 +1,14 @@
 general {
-    lock_cmd = pidof hyprlock || hyprlock       # avoid starting multiple hyprlock instances.
-    before_sleep_cmd = loginctl lock-session    # lock before suspend.
-    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
+    lock_cmd = pidof hyprlock || hyprlock
+    before_sleep_cmd = loginctl lock-session
+    after_sleep_cmd = hyprctl dispatch dpms on
 }
 
 listener {
-    timeout = 300 
-    on-timeout = brightnessctl -s set 10         # set monitor backlight to minimum, avoid 0 on OLED monitor.
-    on-resume = brightnessctl -r                 # monitor backlight restore.
-    id = screen_brightness       
+    timeout = 300
+    on-timeout = brightnessctl -s set 10
+    on-resume = brightnessctl -r
+    id = screen_brightness
 }
 
 listener {

--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -1,10 +1,11 @@
 ################
 ### MONITORS ###
 ################
-monitor= eDP-1, preffered, auto, 1
-monitor = HDMI-A-1, preffered, auto, 1, mirror, eDP-1
+monitor= eDP-1, preferred, auto, 1
+monitor = HDMI-A-1, preferred, auto, 1, mirror, eDP-1
 source = ~/.cache/wal/colors-hyprland.conf
 exec-once = wal -R
+exec-once = ~/.config/hypr/scripts/autopywal.sh &
 
 ###################
 ### PROGRAMS    ###
@@ -23,7 +24,8 @@ exec-once = xdg-desktop-portal &
 exec-once = xdg-desktop-portal-gtk &
 exec-once = wl-paste --watch cliphist store
 exec-once = pkill -f nm-applet || nm-applet --indicator
-exec-once = /usr/lib/polkit-gnome/polkit-agent-helper-1
+# Use standard polkit agent for Wayland sessions
+exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 exec-once = /usr/bin/gnome-keyring-daemon --start --components=secrets,ssh,gpg
 exec-once = xdotool & 
 
@@ -178,10 +180,10 @@ bind = $mainMod, E, exec, $fileManager
 bind = $mainMod, Z, togglefloating,
 bind = $mainMod, P, pseudo, # dwindle
 bind = $mainMod, J, togglesplit, # dwindle
-bind = $mainMod, period, exec, rofi -modi emoji -show emoji 
+bind = $mainMod, period, exec, rofi -modi emoji -show emoji
 bind = $mainMod, V, exec, cliphist list | rofi -dmenu -p "" | cliphist decode | wl-copy && wl-paste --no-newline
 
-bind = $mainMod, K, exec, ~/.config/hypr/scripts/toggle_idle.sh 
+bind = $mainMod, K, exec, ~/.config/hypr/scripts/toggle_idle.sh
 bind = $mainMod, I, exec, kitty -e nmtui
 bind = $mainMod, B, exec, blueman-manager
 

--- a/hypr/hyprpaper.conf
+++ b/hypr/hyprpaper.conf
@@ -1,8 +1,12 @@
 # ~/.config/hypr/hyprpaper.conf
 
-preload = /home/wolfie/Pulpit/Osobiste/Tapety/retro2.png
+# Default wallpaper location. The installer will rewrite this to an absolute
+# path based on your actual wallpaper file under $HOME/Pictures/Wallpapers or
+# $HOME/.config/wallpapers.
 
-wallpaper = ,/home/wolfie/Pulpit/Osobiste/Tapety/retro2.png
+preload = ~/.config/wallpapers/current.png
+
+wallpaper = ,~/.config/wallpapers/current.png
 
 splash = false
 ipc = off

--- a/hypr/scripts/autopywal.sh
+++ b/hypr/scripts/autopywal.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
 HYPRLAND_CONF="$HOME/.config/hypr/hyprland.conf"
+HYPERPAPER_CONF="$HOME/.config/hypr/hyprpaper.conf"
 PYWAL_CMD="wal -i --saturate 0.4"
 SLEEP_TIME=5
 
 get_wallpaper_path() {
-    grep 'wallpaper\s*=' "$HYPRLAND_CONF" | 
-    tail -n 1 | 
-    awk -F '[=,]' '{print $NF}' | 
-    tr -d '[:space:]"'
+    if [ -f "$HYPERPAPER_CONF" ]; then
+        grep -E '^wallpaper\s*=' "$HYPERPAPER_CONF" | tail -n 1 | awk -F '[=,]' '{print $NF}' | tr -d '[:space:]"'
+    else
+        grep 'wallpaper\s*=' "$HYPRLAND_CONF" | tail -n 1 | awk -F '[=,]' '{print $NF}' | tr -d '[:space:]"'
+    fi
 }
 
 CURRENT_WALLPAPER=""
@@ -21,6 +23,10 @@ while true; do
 
         if [ -f "$NEW_WALLPAPER" ]; then
             $PYWAL_CMD "$NEW_WALLPAPER"
+            # Sync Waybar's local colors import
+            if [ -f "$HOME/.cache/wal/colors-waybar.css" ]; then
+                install -D -m 0644 "$HOME/.cache/wal/colors-waybar.css" "$HOME/.config/waybar/colors-waybar.css"
+            fi
             CURRENT_WALLPAPER="$NEW_WALLPAPER"
         else
             echo "BŁĄD: Plik tapety nie istnieje: $NEW_WALLPAPER"

--- a/hypr/scripts/powermenu_pywal.sh
+++ b/hypr/scripts/powermenu_pywal.sh
@@ -37,6 +37,16 @@ ROFI_ARGS=(
     -theme-str "inputbar {enabled: false;}"
 )
 
+# Fallback to a minimal built-in theme if the external theme is missing
+if [ ! -f "$HOME/.config/rofi/themes/powermenu-pywal.rasi" ]; then
+  ROFI_ARGS+=( -theme-str "
+    * {background: #1e1e2e; foreground: #cdd6f4;}
+    window {padding: 10px;}
+    listview {lines: 6;}
+    element selected {background: #45475a;}
+  " )
+fi
+
 options="${LOGOUT_OPTION}\n${REBOOT_OPTION}\n${SHUTDOWN_OPTION}\n${CANCEL_OPTION}"
 chosen_raw=$(echo -e "$options" | rofi "${ROFI_ARGS[@]}")
 chosen_text_only=$(echo "$chosen_raw" | sed -e 's/<[^>]*>//g' -e 's/^[ \t]*[^ ]* //')

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installer for Hyprland dotfiles (Arch Linux)
+# - Installs required packages
+# - Deploys configs into XDG locations
+# - Sets up wallpapers and Pywal integration
+# - Fixes paths in configs to be user-agnostic
+
+if ! command -v pacman >/dev/null 2>&1; then
+  echo "This installer currently supports Arch-based systems (pacman)." >&2
+  exit 1
+fi
+
+USER_HOME=${HOME}
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-"$USER_HOME/.config"}
+REPO_ROOT=$(cd "$(dirname "$0")" && pwd)
+
+need_sudo() {
+  if [ "$EUID" -ne 0 ]; then echo sudo; else echo; fi
+}
+
+install_packages() {
+  local pkgs=(
+    hyprland hyprpaper hypridle hyprlock waybar wofi rofi kitty mako wl-clipboard
+    grim slurp swappy brightnessctl pamixer playerctl cliphist power-profiles-daemon
+    polkit-gnome xdg-desktop-portal xdg-desktop-portal-gtk xdg-desktop-portal-hyprland
+    bluez bluez-utils blueman network-manager-applet xdotool gnome-keyring
+    python-pywal fastfetch dunst cava
+    ttf-jetbrains-mono-nerd noto-fonts noto-fonts-emoji
+  )
+
+  echo "Installing packages: ${pkgs[*]}"
+  $(need_sudo) pacman -Syu --needed --noconfirm "${pkgs[@]}" || true
+}
+
+deploy_configs() {
+  mkdir -p "$XDG_CONFIG_HOME"
+
+  # Hypr configs
+  mkdir -p "$XDG_CONFIG_HOME/hypr/scripts"
+  install -Dm0644 "$REPO_ROOT/hypr/hyprland.conf" "$XDG_CONFIG_HOME/hypr/hyprland.conf"
+  install -Dm0644 "$REPO_ROOT/hypr/hyprpaper.conf" "$XDG_CONFIG_HOME/hypr/hyprpaper.conf"
+  install -Dm0644 "$REPO_ROOT/hypr/hypridle.conf" "$XDG_CONFIG_HOME/hypr/hypridle.conf"
+  if [ -f "$REPO_ROOT/hypr/hyprlock.conf" ]; then
+    install -Dm0644 "$REPO_ROOT/hypr/hyprlock.conf" "$XDG_CONFIG_HOME/hypr/hyprlock.conf"
+  else
+    cat > "$XDG_CONFIG_HOME/hypr/hyprlock.conf" <<'EOF'
+# Minimal Hyprlock configuration
+general { grace = 2 }
+background {
+  monitor =
+  path = ~/.config/wallpapers/current.png
+  blur_passes = 1
+  blur_size = 4
+}
+input-field {
+  size = 240, 50
+  outline_thickness = 2
+  dots_size = 0.25
+  dots_spacing = 0.2
+  dots_center = true
+  dots_rounding = -1
+  hide_input = false
+  rounding = -1
+}
+EOF
+  fi
+
+  # Scripts
+  for f in "$REPO_ROOT"/hypr/scripts/*.sh; do
+    install -Dm0755 "$f" "$XDG_CONFIG_HOME/hypr/scripts/$(basename "$f")"
+  done
+
+  # Waybar
+  mkdir -p "$XDG_CONFIG_HOME/waybar"
+  install -Dm0644 "$REPO_ROOT/waybar/config.jsonc" "$XDG_CONFIG_HOME/waybar/config.jsonc"
+  install -Dm0644 "$REPO_ROOT/waybar/style.css" "$XDG_CONFIG_HOME/waybar/style.css"
+
+  # Kitty
+  if [ -f "$REPO_ROOT/kitty/kitty.conf" ]; then
+    install -Dm0644 "$REPO_ROOT/kitty/kitty.conf" "$XDG_CONFIG_HOME/kitty/kitty.conf"
+  fi
+
+  # Mako
+  if [ -f "$REPO_ROOT/mako/config" ]; then
+    install -Dm0644 "$REPO_ROOT/mako/config" "$XDG_CONFIG_HOME/mako/config"
+  fi
+
+  # Fastfetch
+  if [ -f "$REPO_ROOT/fastfetch/config.jsonc" ]; then
+    install -Dm0644 "$REPO_ROOT/fastfetch/config.jsonc" "$XDG_CONFIG_HOME/fastfetch/config.jsonc"
+    [ -f "$REPO_ROOT/fastfetch/wolf.png" ] && install -Dm0644 "$REPO_ROOT/fastfetch/wolf.png" "$XDG_CONFIG_HOME/fastfetch/wolf.png"
+  fi
+
+  # Pywal template for Hyprland colors
+  if [ -f "$REPO_ROOT/wal/templates/colors-hyprland.conf" ]; then
+    install -Dm0644 "$REPO_ROOT/wal/templates/colors-hyprland.conf" "$XDG_CONFIG_HOME/wal/templates/colors-hyprland.conf"
+  fi
+}
+
+setup_wallpapers() {
+  local wp_dir="$XDG_CONFIG_HOME/wallpapers"
+  mkdir -p "$wp_dir"
+
+  # Copy repo wallpapers if present
+  if compgen -G "$REPO_ROOT/wallpapers/*" >/dev/null; then
+    install -Dm0644 "$REPO_ROOT"/wallpapers/* "$wp_dir/" || true
+  fi
+
+  # Choose a default wallpaper: prefer current.png/jpg if exists, else first image
+  if [ -f "$wp_dir/current.png" ] || [ -f "$wp_dir/current.jpg" ] || [ -f "$wp_dir/current.jpeg" ] || [ -f "$wp_dir/current.webp" ]; then
+    :
+  else
+    first=$(ls -1 "$wp_dir"/*.{png,jpg,jpeg,webp} 2>/dev/null | head -n 1 || true)
+    if [ -n "${first:-}" ]; then
+      ext="${first##*.}"
+      cp -f "$first" "$wp_dir/current.$ext"
+    fi
+  fi
+
+  # Update hyprpaper.conf to point to current image
+  current_any=$(ls -1 "$wp_dir"/current.* 2>/dev/null | head -n 1 || true)
+  if [ -n "${current_any:-}" ]; then
+    esc_current=${current_any//\//\/}
+    sed -i "s#^preload\s*=.*#preload = ${esc_current}#" "$XDG_CONFIG_HOME/hypr/hyprpaper.conf" || true
+    sed -i "s#^wallpaper\s*=.*#wallpaper = ,${esc_current}#" "$XDG_CONFIG_HOME/hypr/hyprpaper.conf" || true
+  fi
+}
+
+fix_paths_and_pywal() {
+  # Replace any lingering absolute /home/<user> paths with ~
+  local files=(
+    "$XDG_CONFIG_HOME/waybar/style.css"
+    "$XDG_CONFIG_HOME/hypr/hyprpaper.conf"
+    "$XDG_CONFIG_HOME/hypr/hyprland.conf"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    sed -i "s#${USER_HOME}/#~/#g" "$f" || true
+  done
+
+  # Generate Pywal colors from current wallpaper if available
+  if command -v wal >/dev/null 2>&1; then
+    current_any=$(ls -1 "$XDG_CONFIG_HOME/wallpapers"/current.* 2>/dev/null | head -n 1 || true)
+    if [ -n "${current_any:-}" ]; then
+      wal -i "$current_any" --saturate 0.4 || true
+    fi
+  fi
+
+  # Sync Waybar colors file locally
+  if [ -f "$USER_HOME/.cache/wal/colors-waybar.css" ]; then
+    install -Dm0644 "$USER_HOME/.cache/wal/colors-waybar.css" "$XDG_CONFIG_HOME/waybar/colors-waybar.css"
+  fi
+}
+
+post_install_notes() {
+  cat <<'EOF'
+Done. Next steps:
+- Log into Hyprland.
+- Ensure nm-applet, polkit-gnome agent, and xdg-desktop-portal are running (autostarted).
+- Change wallpaper by replacing ~/.config/wallpapers/current.* and run: hyprctl reload; killall hyprpaper; hyprpaper &
+EOF
+}
+
+main() {
+  install_packages
+  deploy_configs
+  setup_wallpapers
+  fix_paths_and_pywal
+  post_install_notes
+}
+
+main "$@"

--- a/waybar/style.css
+++ b/waybar/style.css
@@ -1,5 +1,5 @@
-/* Importuj kolory wygenerowane przez Pywal */
-@import url("/home/wolfie/.cache/wal/colors-waybar.css");
+/* Import Pywal colors copied by installer to this directory */
+@import url("colors-waybar.css");
 
 /* --- Style ogólne --- */
 * {


### PR DESCRIPTION
Add an Arch Linux installer script and normalize paths and configurations for Hyprland dotfiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0539e22-c97e-4b25-acdb-b168b1baf2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0539e22-c97e-4b25-acdb-b168b1baf2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

